### PR TITLE
Move completed state setting to after the delegate method

### DIFF
--- a/Pod/Classes/NSURLSession/SuccessSessionMock.swift
+++ b/Pod/Classes/NSURLSession/SuccessSessionMock.swift
@@ -59,8 +59,8 @@ class SuccessSessionMock : SessionMock {
             if let delegate = session.delegate as? NSURLSessionTaskDelegate {
                 
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
-                    task._state = .Completed
                     delegate.URLSession?(session, task: task, didCompleteWithError: nil)
+                    task._state = .Completed
                 }
             }
         }


### PR DESCRIPTION
The docs for [NSURLSessionTaskState](https://developer.apple.com/library/prerelease/ios/documentation/Foundation/Reference/NSURLSessionTask_class/index.html#//apple_ref/swift/enum/c:@E@NSURLSessionTaskState) states that once `state` is `.Completed` there won't be any more delegate callbacks, so I've moved the setting of the state to after the delegate call.
