### PR TITLE
Remove evaluator struct from NSURLSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 
 ### unreleased
++ Remove Evaluator struct from NSURLSession
+
 
 ### 0.6.1
 + Tweak to return values of RequestEvaluator to be explicit about intent

--- a/Example/Tests/NSURLSessionTests.swift
+++ b/Example/Tests/NSURLSessionTests.swift
@@ -238,7 +238,7 @@ class NSURLSessionTests: XCTestCase {
         let conf = NSURLSessionConfiguration.defaultSessionConfiguration()
         let delegate = SessionTestDelegate(expectations: [ ])
         let session = NSURLSession(configuration: conf, delegate: delegate, delegateQueue: NSOperationQueue())
-        NSURLSession.Evaluator.requestEvaluator = { request in
+        NSURLSession.requestEvaluator = { request in
             return .Reject
         }
         

--- a/Pod/Classes/NSURLSession/NSURLSession+Swizzle.swift
+++ b/Pod/Classes/NSURLSession/NSURLSession+Swizzle.swift
@@ -21,19 +21,17 @@ extension NSURLSession {
      */
     public static var debugMockRequests: RequestDebugLevel = .None
     
+    private static let defaultEvaluator: RequestEvaluator = { _ in return .PassThrough }
+    
     /**
      Set this to a block that will decide whether or not a request must be mocked.
      */
-    public struct Evaluator {
-        private static let defaultEvaluator: RequestEvaluator = { _ in return .PassThrough }
-        
-        public static var requestEvaluator: RequestEvaluator = defaultEvaluator {
-            didSet {
-                NSURLSession.swizzleIfNeeded()
-            }
+    public static var requestEvaluator: RequestEvaluator = defaultEvaluator {
+        didSet {
+            NSURLSession.swizzleIfNeeded()
         }
     }
-    
+
     
     // MARK: - Swizling
     
@@ -64,7 +62,7 @@ extension NSURLSession {
             return task
         }
         
-        guard NSURLSession.Evaluator.requestEvaluator(request) == .PassThrough else {
+        guard NSURLSession.requestEvaluator(request) == .PassThrough else {
             let exception = NSException(name: "Mocking Exception",
                 reason: "Request \(request) was not mocked but is required to be mocked",
                 userInfo: nil)
@@ -92,7 +90,7 @@ extension NSURLSession {
             return task
         }
         
-        guard NSURLSession.Evaluator.requestEvaluator(request) == .PassThrough else {
+        guard NSURLSession.requestEvaluator(request) == .PassThrough else {
             let exception = NSException(name: "Mocking Exception",
                 reason: "Request \(request) was not mocked but is required to be mocked",
                 userInfo: nil)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ NSURLSession.removeAllMocks(of: request)
 If you would like to fail requests that haven't been mocked, set the NSURLSession's request evaluator to return whether or not the requests must be allowed. For example, to ensure that all calls to Net-A-Porter's domain are mocked you would:
 
 ```swift
-NSURLSession.Evaluator.requestEvaluator = { request in
+NSURLSession.requestEvaluator = { request in
     guard let url = request.URL else { return .Reject }
 
     return url.host == "www.net-a-porter.com" ? .Reject : .PassThrough


### PR DESCRIPTION
Hey @nap-sam-dean,

So it turns out that the struct wasn't needed -- don't know what I was doing!
