### PR TITLE
Custom mock response data based on regex URL matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 
 ### unreleased
 + Remove Evaluator struct from NSURLSession
-
++ Added a block parameter when mocking to use matching components in the URL in the response body
 
 ### 0.6.1
 + Tweak to return values of RequestEvaluator to be explicit about intent

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
@@ -834,6 +834,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4A518EBE808D9AA8C73682501DE77162 /* AFNetworking.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1020,6 +1021,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4A518EBE808D9AA8C73682501DE77162 /* AFNetworking.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1037,6 +1039,7 @@
 				PRODUCT_NAME = AFNetworking;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Tests/NSURLSessionTests.swift
+++ b/Example/Tests/NSURLSessionTests.swift
@@ -248,4 +248,38 @@ class NSURLSessionTests: XCTestCase {
                 XCTAssertTrue(exception.name == "Mocking Exception")
             }) {}
     }
+
+    func testSession_WithBlock_ShouldReturnModifiedData() {
+        // Create an expression which will match the product id
+        let expression = "http://www.example.com/product/([0-9]{6})"
+        try! NSURLSession.mockEvery(expression) { (matches: [String]) in
+            return matches.first!.dataUsingEncoding(NSUTF8StringEncoding)!
+        }
+
+        // We are going to make two requests, with two different product ids.
+        // When the delegate reports them both complete, we will check that the
+        // data returned was valid for that specific URL
+        let expectation1 = self.expectationWithDescription("Complete called for request 123456")
+        let expectation2 = self.expectationWithDescription("Complete called for request 654321")
+
+        let conf = NSURLSessionConfiguration.defaultSessionConfiguration()
+        let delegate = SessionTestDelegate(expectations: [ expectation1, expectation2 ])
+        let session = NSURLSession(configuration: conf, delegate: delegate, delegateQueue: NSOperationQueue())
+
+        // Perform two tasks
+        let request1 = NSURLRequest(URL: NSURL(string: "http://www.example.com/product/123456")!)
+        let task1 = session.dataTaskWithRequest(request1)
+        task1.resume()
+
+        let request2 = NSURLRequest(URL: NSURL(string: "http://www.example.com/product/654321")!)
+        let task2 = session.dataTaskWithRequest(request2)
+        task2.resume()
+
+        self.waitForExpectationsWithTimeout(1) { timeoutError in
+            // Make sure it was the mock and not a valid response!
+            XCTAssertEqual(delegate.dataKeyedByTaskIdentifier[task1.taskIdentifier], "123456".dataUsingEncoding(NSUTF8StringEncoding))
+            XCTAssertEqual(delegate.dataKeyedByTaskIdentifier[task2.taskIdentifier], "654321".dataUsingEncoding(NSUTF8StringEncoding))
+        }
+
+    }
 }

--- a/Example/Tests/NSURLSessionTests.swift
+++ b/Example/Tests/NSURLSessionTests.swift
@@ -282,4 +282,5 @@ class NSURLSessionTests: XCTestCase {
         }
 
     }
+
 }

--- a/Example/Tests/SimpleRequestMatcherTests.swift
+++ b/Example/Tests/SimpleRequestMatcherTests.swift
@@ -19,7 +19,14 @@ class SimpleRequestMatcherTests: XCTestCase {
         let matcher = SimpleRequestMatcher(url: URL, method: "GET")
         
         let r1 = NSURLRequest(URL: URL)
-        XCTAssertTrue(matcher.matches(r1))
+
+        let result = matcher.matches(r1)
+        switch(result) {
+        case .NoMatch:
+            XCTFail("Should have matched")
+        case .Matches(let extractions):
+            XCTAssertEqual([], extractions)
+        }
     }
     
     func testRequestMatcher_WithOddMethod_ShouldNotMatch() {
@@ -29,16 +36,29 @@ class SimpleRequestMatcherTests: XCTestCase {
         let matcher = SimpleRequestMatcher(url: URL, method: "HEAD")
         
         let r1 = NSURLRequest(URL: URL)
-        XCTAssertFalse(matcher.matches(r1))
+        let result = matcher.matches(r1)
+        switch(result) {
+        case .NoMatch:
+            break
+        case .Matches(_):
+            XCTFail("Should not have matched")
+        }
     }
     
     func testRequestMatcher_WithRegex_ShouldMatch() {
-        let path = ".*/a/b/c"
+        let path = ".*/a/b/(.)"
         let matcher = try! SimpleRequestMatcher(expression: path, method: "GET")
         
         let URL = NSURL(string: "www.example.com/a/b/c")!
         let r1 = NSURLRequest(URL: URL)
-        XCTAssertTrue(matcher.matches(r1))
+
+        let result = matcher.matches(r1)
+        switch(result) {
+        case .NoMatch:
+            XCTFail("Should have matched")
+        case .Matches(let extractions):
+            XCTAssertEqual([ "c" ], extractions)
+        }
     }
     
     func testRequestMatcher_WithRegex_ShouldNotMatch() {
@@ -47,6 +67,13 @@ class SimpleRequestMatcherTests: XCTestCase {
         
         let URL = NSURL(string: "www.example.com/b/c/a")!
         let r1 = NSURLRequest(URL: URL)
-        XCTAssertFalse(matcher.matches(r1))
+
+        let result = matcher.matches(r1)
+        switch(result) {
+        case .NoMatch:
+            break
+        case .Matches(_):
+            XCTFail("Should not have matched")
+        }
     }
 }

--- a/Example/Tests/SimpleRequestMatcherTests.swift
+++ b/Example/Tests/SimpleRequestMatcherTests.swift
@@ -76,4 +76,21 @@ class SimpleRequestMatcherTests: XCTestCase {
             XCTFail("Should not have matched")
         }
     }
+
+    func testRequestMatcher_WithDuplicateMatch_ShouldMatch() {
+
+        let path = "/product/(...)"
+        let matcher = try! SimpleRequestMatcher(expression: path, method: "GET")
+
+        let URL = NSURL(string: "/product/123/product/456")!
+        let request = NSURLRequest(URL: URL)
+
+        let result = matcher.matches(request)
+        switch(result) {
+        case .NoMatch:
+            XCTFail("Should have matched")
+        case let .Matches(matches):
+            XCTAssertEqual(matches, [ "123", "456" ])
+        }
+    }
 }

--- a/Pod/Classes/Common/MockResponse.swift
+++ b/Pod/Classes/Common/MockResponse.swift
@@ -8,34 +8,22 @@
 
 import Foundation
 
+/**
+ Describes a single response to a mocked request
+*/
 struct MockResponse {
-    /**
-     The mock data to return
-     */
-    let data: NSData?
-    
-    /**
-     An error to return
-     */
-    let error: NSError?
-    
-    /**
-     A set of headers to return
-     */
-    let headers: [String: String]
-    
-    /**
-     The status code to return from the response
-     */
+    let body: NSData?
     let statusCode: Int
+    let headers: [String:String]
+
+    init(body: NSData?, statusCode: Int = 200, headers: [String:String] = [:]) {
+        self.body = body
+        self.statusCode = statusCode
+        self.headers = headers
+    }
 }
 
-extension MockResponse : Equatable { }
-
-func ==(a: MockResponse, b: MockResponse) -> Bool {
-    return (a.data == b.data &&
-            a.statusCode == b.statusCode &&
-            a.error == b.error &&
-            a.headers == b.headers
-    )
-}
+/**
+ Given the URL and the extracted sections, what should be the response data, the status code and the headers.
+*/
+typealias MockResponseHandler = (url: NSURL, extractions: [String]) -> MockResponse

--- a/Pod/Classes/NSURLSession/Matchers/RequestMatcher.swift
+++ b/Pod/Classes/NSURLSession/Matchers/RequestMatcher.swift
@@ -8,8 +8,13 @@
 
 import Foundation
 
+enum MatchesResponse {
+    case NoMatch
+    case Matches(extractions:[String])
+}
+
 protocol RequestMatcher {
 
-    func matches(request: NSURLRequest) -> Bool
+    func matches(request: NSURLRequest) -> MatchesResponse
     
 }

--- a/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
+++ b/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
@@ -9,25 +9,25 @@
 import Foundation
 
 /**
- This struct matches by matching the path to a regular expression and by 
+ This struct matches by matching the path to a regular expression and by
  comparing the methods for equality.
-*/
+ */
 struct SimpleRequestMatcher : RequestMatcher {
-    
+
     let pathMatcher: NSRegularExpression
-    
+
     let method: String
-    
+
     init(url: NSURL, method: String) {
         let path = NSRegularExpression.escapedPatternForString(url.absoluteString)
         try! self.init(expression: "^\(path)$", method: method)
     }
-    
+
     init(expression: String, method: String) throws {
         try self.pathMatcher = NSRegularExpression(pattern: expression, options: NSRegularExpressionOptions.AnchorsMatchLines)
         self.method = method
     }
-    
+
     func matches(request: NSURLRequest) -> MatchesResponse {
         //
         guard request.HTTPMethod == self.method else { return .NoMatch }
@@ -38,15 +38,17 @@ struct SimpleRequestMatcher : RequestMatcher {
         let matches = self.pathMatcher.matchesInString(path, options: [], range: range)
         guard let match = matches.first where matches.count == 1 else { return .NoMatch }
 
+        // If there were any matches, extract them here (match at index 0 is the
+        // whole string - skip that one)
         var extractions = [String]()
-        for n in 0 ..< match.numberOfRanges {
-            guard n > 0 else { continue }
-
-            let range = match.rangeAtIndex(n)
-            let extraction = (path as NSString).substringWithRange(range)
-            extractions.append(extraction)
+        if match.numberOfRanges > 1 {
+            for n in 1 ..< match.numberOfRanges {
+                let range = match.rangeAtIndex(n)
+                let extraction = (path as NSString).substringWithRange(range)
+                extractions.append(extraction)
+            }
         }
-
+        
         return .Matches(extractions: extractions)
     }
     

--- a/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
+++ b/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
@@ -28,13 +28,26 @@ struct SimpleRequestMatcher : RequestMatcher {
         self.method = method
     }
     
-    func matches(request: NSURLRequest) -> Bool {
-        guard request.HTTPMethod == self.method else { return false }
-        
+    func matches(request: NSURLRequest) -> MatchesResponse {
+        //
+        guard request.HTTPMethod == self.method else { return .NoMatch }
+
+        // Get the match
         let path = request.URL?.absoluteString ?? ""
-        let options = NSMatchingOptions(rawValue: 0)
         let range = NSMakeRange(0, path.utf16.count)
-        return pathMatcher.numberOfMatchesInString(path, options: options, range: range) == 1
+        let matches = self.pathMatcher.matchesInString(path, options: [], range: range)
+        guard let match = matches.first where matches.count == 1 else { return .NoMatch }
+
+        var extractions = [String]()
+        for n in 0 ..< match.numberOfRanges {
+            guard n > 0 else { continue }
+
+            let range = match.rangeAtIndex(n)
+            let extraction = (path as NSString).substringWithRange(range)
+            extractions.append(extraction)
+        }
+
+        return .Matches(extractions: extractions)
     }
     
 }

--- a/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
+++ b/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
@@ -36,17 +36,19 @@ struct SimpleRequestMatcher : RequestMatcher {
         let path = request.URL?.absoluteString ?? ""
         let range = NSMakeRange(0, path.utf16.count)
         let matches = self.pathMatcher.matchesInString(path, options: [], range: range)
-        guard let match = matches.first where matches.count == 1 else { return .NoMatch }
+        guard matches.count > 0 else { return .NoMatch }
 
         // If there were any matches, extract them here (match at index 0 is the
         // whole string - skip that one)
         var extractions = [String]()
-        for n in 1 ..< match.numberOfRanges {
-            let range = match.rangeAtIndex(n)
-            let extraction = (path as NSString).substringWithRange(range)
-            extractions.append(extraction)
+        for match in matches {
+            for n in 1 ..< match.numberOfRanges {
+                let range = match.rangeAtIndex(n)
+                let extraction = (path as NSString).substringWithRange(range)
+                extractions.append(extraction)
+            }
         }
-        
+
         return .Matches(extractions: extractions)
     }
     

--- a/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
+++ b/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
@@ -41,12 +41,10 @@ struct SimpleRequestMatcher : RequestMatcher {
         // If there were any matches, extract them here (match at index 0 is the
         // whole string - skip that one)
         var extractions = [String]()
-        if match.numberOfRanges > 1 {
-            for n in 1 ..< match.numberOfRanges {
-                let range = match.rangeAtIndex(n)
-                let extraction = (path as NSString).substringWithRange(range)
-                extractions.append(extraction)
-            }
+        for n in 1 ..< match.numberOfRanges {
+            let range = match.rangeAtIndex(n)
+            let extraction = (path as NSString).substringWithRange(range)
+            extractions.append(extraction)
         }
         
         return .Matches(extractions: extractions)

--- a/Pod/Classes/NSURLSession/MockRegister.swift
+++ b/Pod/Classes/NSURLSession/MockRegister.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-internal class MockRegister {
+class MockRegister {
     
     private var mocks: [SessionMock] = []
     
-    internal func removeAllMocks() {
+    func removeAllMocks() {
         self.mocks.removeAll()
     }
     
-    internal func addMock(mock: SessionMock) {
+    func addMock(mock: SessionMock) {
         self.mocks.append(mock)
     }
     
@@ -24,13 +24,13 @@ internal class MockRegister {
      Remove all mocks matching the given request. All other requests will still
      be mocked
      */
-    internal func removeAllMocks(of request: NSURLRequest) {
+    func removeAllMocks(of request: NSURLRequest) {
         self.mocks = self.mocks.filter { item in
             return !item.matchesRequest(request)
         }
     }
     
-    internal func nextSessionMockForRequest(request: NSURLRequest) -> SessionMock? {
+    func nextSessionMockForRequest(request: NSURLRequest) -> SessionMock? {
         for mock in mocks {
             if mock.matchesRequest(request) {
                 return mock

--- a/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
+++ b/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
@@ -24,7 +24,7 @@ public enum RequestDebugLevel: Int {
 
 /**
  Mocks which are interested in sections of the URL to create the response body
- should pass in functions matching this signature to `mockSingle` or `mockOnce`
+ should pass in functions matching this signature to `mockSingle` or `mockEvery`
 */
 public typealias BodyFunction = [String] -> NSData
 

--- a/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
+++ b/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
@@ -22,6 +22,12 @@ public enum RequestDebugLevel: Int {
     case All
 }
 
+/**
+ Mocks which are interested in sections of the URL to create the response body
+ should pass in functions matching this signature to `mockSingle` or `mockOnce`
+*/
+public typealias BodyFunction = [String] -> NSData
+
 extension NSURLSession {
     
     internal static let register = MockRegister()
@@ -37,7 +43,7 @@ extension NSURLSession {
      */
     public class func mockSingle(request: NSURLRequest, body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) {
         let matcher = SimpleRequestMatcher(url: request.URL!, method: request.HTTPMethod!)
-        self.mockSingle(matcher, body: body, headers: headers, statusCode: statusCode, delay: delay)
+        self.mockSingle(matcher, response: { _ in MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
     }
     
     /**
@@ -51,7 +57,7 @@ extension NSURLSession {
      */
     public class func mockEvery(request: NSURLRequest, body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) {
         let matcher = SimpleRequestMatcher(url: request.URL!, method: request.HTTPMethod!)
-        self.mockEvery(matcher, body: body, headers: headers, statusCode: statusCode, delay: delay)
+        self.mockEvery(matcher, response: { _ in return MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
     }
     
     /**
@@ -66,12 +72,12 @@ extension NSURLSession {
      */
     public class func mockSingle(expression: String, HTTPMethod: String = "GET", body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) throws {
         let matcher = try SimpleRequestMatcher(expression: expression, method: HTTPMethod)
-        self.mockSingle(matcher, body: body, headers: headers, statusCode: statusCode, delay: delay)
+        self.mockSingle(matcher, response: { _ in return MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
     }
-    
+
     /**
      All subsequent requests matching `expression` will successfully return `body`
-     
+
      - parameter expression: The regular expression to compare incoming requests against
      - parameter HTTPMethod: The method to match against
      - parameter body: The data returned by the session data task. If this is `nil` then the didRecieveData callback won't be called.
@@ -81,7 +87,37 @@ extension NSURLSession {
      */
     public class func mockEvery(expression: String, HTTPMethod: String = "GET", body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) throws {
         let matcher = try SimpleRequestMatcher(expression: expression, method: HTTPMethod)
-        self.mockEvery(matcher, body: body, headers: headers, statusCode: statusCode, delay: delay)
+        self.mockEvery(matcher, response: { _ in return MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
+    }
+
+    /**
+     The next request matching `expression` will successfully return the result of `body`, a method where the matches sections of the url as passed in as parameters.
+
+     - parameter expression: The regular expression to compare incoming requests against
+     - parameter HTTPMethod: The method to match against
+     - parameter headers: The headers returned by the session data task
+     - parameter statusCode: The status code (default=200) returned by the session data task
+     - parameter delay: A artificial delay before the session data task starts to return response and data
+     - parameter body: Returns data the data to be  returned by the session data task. If this returns `nil` then the didRecieveData callback won't be called.
+     */
+    public class func mockSingle(expression: String, HTTPMethod: String = "GET", headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay, body: BodyFunction) throws {
+        let matcher = try SimpleRequestMatcher(expression: expression, method: HTTPMethod)
+        self.mockSingle(matcher, response: { (url: NSURL, extractions: [String]) in return MockResponse(body: body(extractions), statusCode: statusCode, headers: headers) }, delay: delay)
+    }
+
+    /**
+     All subsequent requests matching `expression` will successfully return the result of `body`, a method where the matches sections of the url as passed in as parameters.
+
+     - parameter expression: The regular expression to compare incoming requests against
+     - parameter HTTPMethod: The method to match against
+     - parameter headers: The headers returned by the session data task
+     - parameter statusCode: The status code (default=200) returned by the session data task
+     - parameter delay: A artificial delay before the session data task starts to return response and data
+     - parameter body: Returns data the data to be  returned by the session data task. If this returns `nil` then the didRecieveData callback won't be called.
+     */
+    public class func mockEvery(expression: String, HTTPMethod: String = "GET", headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay, body: BodyFunction) throws {
+        let matcher = try SimpleRequestMatcher(expression: expression, method: HTTPMethod)
+        self.mockEvery(matcher, response: { (url: NSURL, extractions: [String]) in return MockResponse(body: body(extractions), statusCode: statusCode, headers: headers) }, delay: delay)
     }
     
     /**
@@ -99,19 +135,16 @@ extension NSURLSession {
         self.register.removeAllMocks(of: request)
     }
 
-    
     //MARK: Private methods
     
     // Add a request matcher to the list of mocks
-    private class func mockSingle(matcher: RequestMatcher, body: NSData? , headers: [String: String], statusCode: Int, delay: Double) {
-        let response = MockResponse(data: body, error: nil, headers: headers, statusCode: statusCode)
+    private class func mockSingle(matcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.register.addMock(SingleSuccessSessionMock(matching: matcher, response: response, delay: delay))
         swizzleIfNeeded()
     }
     
     // Add a request matcher to the list of mocks
-    private class func mockEvery(matcher: RequestMatcher, body: NSData? , headers: [String: String], statusCode: Int, delay: Double) {
-        let response = MockResponse(data: body, error: nil, headers: headers, statusCode: statusCode)
+    private class func mockEvery(matcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.register.addMock(SuccessSessionMock(matching: matcher, response: response, delay: delay))
         swizzleIfNeeded()
     }

--- a/Pod/Classes/NSURLSession/SuccessSessionMock.swift
+++ b/Pod/Classes/NSURLSession/SuccessSessionMock.swift
@@ -13,61 +13,74 @@ private let mult = Double(NSEC_PER_SEC)
 class SuccessSessionMock : SessionMock {
     
     private let requestMatcher: RequestMatcher
-    private let response: MockResponse
+    private let response: MockResponseHandler
     private let delay: Double
     
-    init(matching requestMatcher: RequestMatcher, response: MockResponse, delay: Double) {
+    init(matching requestMatcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.requestMatcher = requestMatcher
         self.response = response
         self.delay = delay
     }
     
     func matchesRequest(request: NSURLRequest) -> Bool {
-        return requestMatcher.matches(request)
+        switch(self.requestMatcher.matches(request)) {
+        case .Matches: return true
+        case .NoMatch: return false
+        }
     }
     
     func consumeRequest(request: NSURLRequest, session: NSURLSession) throws -> NSURLSessionDataTask {
-        // If this isn't for us, don't produce a task
-        guard self.matchesRequest(request) else { throw SessionMockError.InvalidRequest(request: request) }
-        
-        let task = MockSessionDataTask() { task in
-            task._state = .Running
-            
-            let timeDelta = 0.02
-            var time = self.delay
-            
-            if let delegate = session.delegate as? NSURLSessionDataDelegate {
+
+        switch (self.requestMatcher.matches(request)) {
+
+        // If this isn't for us, we shouldn't have been called, throw and let
+        // everyone know!
+        case .NoMatch:
+            throw SessionMockError.InvalidRequest(request: request)
+
+        // Use the extractions from the match to create the data
+        case .Matches(let extractions):
+            let task = MockSessionDataTask() { task in
+                task._state = .Running
                 
-                if let body = self.response.data {
+                let timeDelta = 0.02
+                var time = self.delay
+
+                let response = self.response(url: request.URL!, extractions: extractions)
+                
+                if let delegate = session.delegate as? NSURLSessionDataDelegate {
                     
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
-                        let response = NSHTTPURLResponse(URL: request.URL!, statusCode: self.response.statusCode, HTTPVersion: "HTTP/1.1", headerFields: self.response.headers)!
-                        task.response = response
-                        delegate.URLSession?(session, dataTask: task, didReceiveResponse: response) { _ in }
-                    }
-                    
-                    time += timeDelta
+                    if let body = response.body {
                         
-                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
-                        delegate.URLSession?(session, dataTask: task, didReceiveData: body)
+                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
+                            let response = NSHTTPURLResponse(URL: request.URL!, statusCode: response.statusCode, HTTPVersion: "HTTP/1.1", headerFields: response.headers)!
+                            task.response = response
+                            delegate.URLSession?(session, dataTask: task, didReceiveResponse: response) { _ in }
+                        }
+                        
+                        time += timeDelta
+                            
+                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
+                            delegate.URLSession?(session, dataTask: task, didReceiveData: body)
+                        }
+                        
+                        time += timeDelta
                     }
+                }
+                
+                if let delegate = session.delegate as? NSURLSessionTaskDelegate {
                     
-                    time += timeDelta
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
+                        delegate.URLSession?(session, task: task, didCompleteWithError: nil)
+                        task._state = .Completed
+                    }
                 }
             }
             
-            if let delegate = session.delegate as? NSURLSessionTaskDelegate {
-                
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
-                    delegate.URLSession?(session, task: task, didCompleteWithError: nil)
-                    task._state = .Completed
-                }
-            }
+            task._originalRequest = request
+            
+            return task
         }
-        
-        task._originalRequest = request
-        
-        return task
     }
     
 }

--- a/Pod/Classes/NSURLSession/SuccessSessionMock.swift
+++ b/Pod/Classes/NSURLSession/SuccessSessionMock.swift
@@ -11,29 +11,29 @@ import Foundation
 private let mult = Double(NSEC_PER_SEC)
 
 class SuccessSessionMock : SessionMock {
-    
+
     private let requestMatcher: RequestMatcher
     private let response: MockResponseHandler
     private let delay: Double
-    
+
     init(matching requestMatcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.requestMatcher = requestMatcher
         self.response = response
         self.delay = delay
     }
-    
+
     func matchesRequest(request: NSURLRequest) -> Bool {
         switch(self.requestMatcher.matches(request)) {
         case .Matches: return true
         case .NoMatch: return false
         }
     }
-    
+
     func consumeRequest(request: NSURLRequest, session: NSURLSession) throws -> NSURLSessionDataTask {
 
         switch (self.requestMatcher.matches(request)) {
 
-        // If this isn't for us, we shouldn't have been called, throw and let
+            // If this isn't for us, we shouldn't have been called, throw and let
         // everyone know!
         case .NoMatch:
             throw SessionMockError.InvalidRequest(request: request)
@@ -42,67 +42,65 @@ class SuccessSessionMock : SessionMock {
         case .Matches(let extractions):
             let task = MockSessionDataTask() { task in
                 task._state = .Running
-                
+
                 let timeDelta = 0.02
                 var time = self.delay
 
                 let response = self.response(url: request.URL!, extractions: extractions)
-                
-                if let delegate = session.delegate as? NSURLSessionDataDelegate {
-                    
-                    if let body = response.body {
-                        
-                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
-                            let response = NSHTTPURLResponse(URL: request.URL!, statusCode: response.statusCode, HTTPVersion: "HTTP/1.1", headerFields: response.headers)!
-                            task.response = response
-                            delegate.URLSession?(session, dataTask: task, didReceiveResponse: response) { _ in }
-                        }
-                        
-                        time += timeDelta
-                            
-                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
-                            delegate.URLSession?(session, dataTask: task, didReceiveData: body)
-                        }
-                        
-                        time += timeDelta
+
+                if let delegate = session.delegate as? NSURLSessionDataDelegate,
+                    let body = response.body {
+
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
+                        let response = NSHTTPURLResponse(URL: request.URL!, statusCode: response.statusCode, HTTPVersion: "HTTP/1.1", headerFields: response.headers)!
+                        task.response = response
+                        delegate.URLSession?(session, dataTask: task, didReceiveResponse: response) { _ in }
                     }
+
+                    time += timeDelta
+
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
+                        delegate.URLSession?(session, dataTask: task, didReceiveData: body)
+                    }
+
+                    time += timeDelta
                 }
-                
+
                 if let delegate = session.delegate as? NSURLSessionTaskDelegate {
-                    
+
                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(mult * time)), dispatch_get_main_queue()) {
                         delegate.URLSession?(session, task: task, didCompleteWithError: nil)
                         task._state = .Completed
                     }
                 }
             }
-            
+
             task._originalRequest = request
-            
+
             return task
         }
     }
-    
+
 }
 
 class SingleSuccessSessionMock : SuccessSessionMock {
-    
+
     var canRun = true
-    
+
     override func matchesRequest(request: NSURLRequest) -> Bool {
         return canRun && super.matchesRequest(request)
     }
-    
+
     override func consumeRequest(request: NSURLRequest, session: NSURLSession) throws -> NSURLSessionDataTask {
         guard self.matchesRequest(request) else { throw SessionMockError.InvalidRequest(request: request) }
-        
+
         guard canRun else { throw SessionMockError.HasAlreadyRun }
-        
+
         let task = try super.consumeRequest(request, session: session)
-        
+
         canRun = false
-        
+
         return task
     }
-    
+
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ The parameters `body` and `delay` are optional if you want you code to be a bit 
 NSURLSession.mockEvery(request)
 ```
 
+If you want your response to depend on the URL called, you can pass in a function like this:
+
+```objc
+let URL = NSURL(string: "https://www.example.com/product/([0-9]{6})")!
+let request = NSURLRequest.init(URL: URL)
+
+// Return a valid test product JSON response with the correct pid
+NSURLSession.mockEvery(request) { (matches:[String]) in
+    let pid = matches.first!
+    return "{ 'productId':'\(pid)', 'description':'This is a test product' }".datawithEncoding(UTF8StringEncoding)!
+}
+```
+
 To remove all the mocks (or just some of them) you can do
 
 


### PR DESCRIPTION
Hey. This should fix #4 :)

This should let mocks use the incoming URL to define their output body. The readme explains this better :)

I've also made the MockResponse struct be created dynamically by a block instead of created when you call `mockEvery` - this should open us up to also allowing customisation of the headers and statusCodes, though I don't see a use case yet, so YAGNI :)

I've preserved the original mock... methods parameter order out of politeness, but the two new methods I've added have the block at the end so we can use Swift's trailing block syntax. I don't know which we prefer, parameter order consistency or backwards compatibility. It's trivial either way - I happen ot have taken the safe option in this PR. I can change that if you want.

S
