### PR TITLE
Add ephemeral mock priority to mock register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 ### unreleased
 + Remove Evaluator struct from NSURLSession
 + Added a block parameter when mocking to use matching components in the URL in the response body
++ Single mocks now have priority over permanent mocks
 
 ### 0.6.1
 + Tweak to return values of RequestEvaluator to be explicit about intent

--- a/Example/Tests/AFNetworkingTests.swift
+++ b/Example/Tests/AFNetworkingTests.swift
@@ -25,7 +25,7 @@ class AFNetworkingTests: XCTestCase {
         let body = "{ \"data\": 1 }".dataUsingEncoding(NSUTF8StringEncoding)!
         let request = NSURLRequest.init(URL: URL)
         let headers = [ "Content-Type" : "application/json"]
-        NSURLSession.mockSingle(request, body: body, headers: headers)
+        NSURLSession.mockNext(request, body: body, headers: headers)
 
         let manager = AFHTTPSessionManager()
         
@@ -51,7 +51,7 @@ class AFNetworkingTests: XCTestCase {
         let request = NSMutableURLRequest.init(URL: URL)
         request.HTTPMethod = "POST"
         let headers = [ "Content-Type" : "application/json"]
-        NSURLSession.mockSingle(request, body: body, headers: headers)
+        NSURLSession.mockNext(request, body: body, headers: headers)
         
         let manager = AFHTTPSessionManager()
         

--- a/Example/Tests/MockRegisterTests.swift
+++ b/Example/Tests/MockRegisterTests.swift
@@ -13,7 +13,6 @@ import XCTest
 class MockRegisterTests: XCTestCase {
     
     class TestSessionMock : SessionMock {
-        var runsOnce = false
         let requestString : String
         
         init(requestString: String) {
@@ -28,19 +27,25 @@ class MockRegisterTests: XCTestCase {
             return NSURLSessionDataTask()
         }
     }
-    
-    class TestEphemeralMock : TestSessionMock {
-        override init(requestString: String) {
-            super.init(requestString: requestString)
-            self.runsOnce = true
-        }
-    }
 
-    func testMockRegister_WithTestMock_ShouldReturnTestMockWithCorrectURL() {
+
+    func testMockRegister_WithPermanentTestMock_ShouldReturnTestMockWithCorrectURL() {
         let register = MockRegister()
         let mock = TestSessionMock(requestString: "test")
         
-        register.addMock(mock)
+        register.addPermanentMock(mock)
+        
+        let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
+        let returnedMock = register.nextSessionMockForRequest(request)
+        
+        XCTAssertNotNil(returnedMock)
+    }
+    
+    func testMockRegister_WithEphemeralTestMock_ShouldReturnTestMockWithCorrectURL() {
+        let register = MockRegister()
+        let mock = TestSessionMock(requestString: "test")
+        
+        register.addEphemeralMock(mock)
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
         let returnedMock = register.nextSessionMockForRequest(request)
@@ -52,7 +57,8 @@ class MockRegisterTests: XCTestCase {
         let register = MockRegister()
         let mock = TestSessionMock(requestString: "test")
         
-        register.addMock(mock)
+        register.addPermanentMock(mock)
+        register.addEphemeralMock(mock)
         
         register.removeAllMocks()
         let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
@@ -65,7 +71,8 @@ class MockRegisterTests: XCTestCase {
         let register = MockRegister()
         let mock = TestSessionMock(requestString: "test")
         
-        register.addMock(mock)
+        register.addPermanentMock(mock)
+        register.addEphemeralMock(mock)
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.example.com")!)
         let returnedMock = register.nextSessionMockForRequest(request)
@@ -73,13 +80,33 @@ class MockRegisterTests: XCTestCase {
         XCTAssertNil(returnedMock)
     }
     
-    func testMockRegister_WithRemovingCertainRequests_ShouldFilterOut() {
+    func testMockRegister_WithPermanentMockRemovingCertainRequests_ShouldFilterOut() {
         let register = MockRegister()
         let mock = TestSessionMock(requestString: "test")
         let permanent = TestSessionMock(requestString: "shouldstillbethere")
         
-        register.addMock(mock)
-        register.addMock(permanent)
+        register.addPermanentMock(mock)
+        register.addPermanentMock(permanent)
+        
+        let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
+        let permanentRequest = NSURLRequest(URL: NSURL(string: "http://www.example.com/shouldstillbethere")!)
+        
+        register.removeAllMocks(of: request)
+        
+        let permanentMock = register.nextSessionMockForRequest(permanentRequest)
+        let fleetingMock = register.nextSessionMockForRequest(request)
+        
+        XCTAssertNotNil(permanentMock)
+        XCTAssertNil(fleetingMock)
+    }
+    
+    func testMockRegister_WithEphemeralMockRemovingCertainRequests_ShouldFilterOut() {
+        let register = MockRegister()
+        let mock = TestSessionMock(requestString: "test")
+        let permanent = TestSessionMock(requestString: "shouldstillbethere")
+        
+        register.addEphemeralMock(mock)
+        register.addEphemeralMock(permanent)
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
         let permanentRequest = NSURLRequest(URL: NSURL(string: "http://www.example.com/shouldstillbethere")!)
@@ -114,7 +141,7 @@ class MockRegisterTests: XCTestCase {
         let register = MockRegister()
         let mock = TestEphemeralMock(requestString: "test")
         
-        register.addMock(mock)
+        register.addEphemeralMock(mock)
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
         let notNilMock = register.nextSessionMockForRequest(request)
@@ -126,21 +153,23 @@ class MockRegisterTests: XCTestCase {
     func testMockRegister_WithEphemeralAndPermanentMock_ShouldPrioritizeEphemeralMock() {
         
         let register = MockRegister()
-        let mock = TestEphemeralMock(requestString: "test")
+        let mock = TestSessionMock(requestString: "example.com/test")
         let permanentMock = TestSessionMock(requestString: "test")
         let secondPermanentMock = TestSessionMock(requestString: "test")
         
-        register.addMock(permanentMock)
-        register.addMock(mock)
-        register.addMock(secondPermanentMock)
+        register.addPermanentMock(permanentMock)
+        register.addEphemeralMock(mock)
+        register.addPermanentMock(secondPermanentMock)
         
         let request = NSURLRequest(URL: NSURL(string: "http://www.example.com/test")!)
-        guard let ephemeral = register.nextSessionMockForRequest(request) else {
+        guard let ephemeral = register.nextSessionMockForRequest(request) as? TestSessionMock else {
             XCTFail("Could not get ephemeral mock")
             return
         }
         
-        XCTAssertTrue(ephemeral.runsOnce)
+        
+        XCTAssertNotNil(ephemeral)
+        XCTAssertEqual(ephemeral.requestString, "example.com/test")
     }
 }
 

--- a/Example/Tests/NSURLSessionTests.swift
+++ b/Example/Tests/NSURLSessionTests.swift
@@ -65,11 +65,11 @@ class NSURLSessionTests: XCTestCase {
         let URL = NSURL(string: "https://www.example.com/1")!
         let body1 = "Test response 1".dataUsingEncoding(NSUTF8StringEncoding)!
         let request1 = NSURLRequest.init(URL: URL)
-        NSURLSession.mockSingle(request1, body: body1)
+        NSURLSession.mockNext(request1, body: body1)
         
         let body2 = "Test response 2".dataUsingEncoding(NSUTF8StringEncoding)!
         let request2 = NSURLRequest.init(URL: URL)
-        NSURLSession.mockSingle(request2, body: body2)
+        NSURLSession.mockNext(request2, body: body2)
         
         // Create a session
         let conf = NSURLSessionConfiguration.defaultSessionConfiguration()
@@ -172,7 +172,7 @@ class NSURLSessionTests: XCTestCase {
         let body = "Test response 1".dataUsingEncoding(NSUTF8StringEncoding)!
         let request = NSURLRequest.init(URL: URL)
         let headers = ["Content-Type" : "application/test", "Custom-Header" : "Is custom"]
-        NSURLSession.mockSingle(request, body: body, headers: headers, statusCode: 200)
+        NSURLSession.mockNext(request, body: body, headers: headers, statusCode: 200)
         
         // Create a session
         let conf = NSURLSessionConfiguration.defaultSessionConfiguration()

--- a/Example/Tests/NSURLSessionTests.swift
+++ b/Example/Tests/NSURLSessionTests.swift
@@ -280,7 +280,5 @@ class NSURLSessionTests: XCTestCase {
             XCTAssertEqual(delegate.dataKeyedByTaskIdentifier[task1.taskIdentifier], "123456".dataUsingEncoding(NSUTF8StringEncoding))
             XCTAssertEqual(delegate.dataKeyedByTaskIdentifier[task2.taskIdentifier], "654321".dataUsingEncoding(NSUTF8StringEncoding))
         }
-
     }
-
 }

--- a/Pod/Classes/NSURLSession/MockRegister.swift
+++ b/Pod/Classes/NSURLSession/MockRegister.swift
@@ -10,14 +10,20 @@ import Foundation
 
 class MockRegister {
     
-    private var mocks: [SessionMock] = []
+    private var permanentMocks: [SessionMock] = []
+    private var ephemeralMocks: [SessionMock] = []
     
     func removeAllMocks() {
-        self.mocks.removeAll()
+        self.permanentMocks.removeAll()
+        self.ephemeralMocks.removeAll()
     }
     
     func addMock(mock: SessionMock) {
-        self.mocks.append(mock)
+        if mock.runsOnce {
+            self.ephemeralMocks.append(mock)
+        } else {
+            self.permanentMocks.append(mock)
+        }
     }
     
     /**
@@ -25,13 +31,30 @@ class MockRegister {
      be mocked
      */
     func removeAllMocks(of request: NSURLRequest) {
-        self.mocks = self.mocks.filter { item in
-            return !item.matchesRequest(request)
+        self.permanentMocks = self.permanentMocks.filter {
+            return !$0.matchesRequest(request)
+        }
+        self.ephemeralMocks = self.ephemeralMocks.filter {
+            return !$0.matchesRequest(request)
         }
     }
     
+    /*
+    Returns the next mock for the given request. If the next mock is ephemeral, 
+    it also removes it from the pool of ephemeral mocks.
+    */
     func nextSessionMockForRequest(request: NSURLRequest) -> SessionMock? {
-        for mock in mocks {
+        let mocksCopy = self.ephemeralMocks
+        
+        //Ephemeral mocks have precedence over permanent mocks
+        for (index, mock) in mocksCopy.enumerate() {
+            if mock.matchesRequest(request) {
+                self.ephemeralMocks.removeAtIndex(index)
+                return mock
+            }
+        }
+        
+        for mock in self.permanentMocks {
             if mock.matchesRequest(request) {
                 return mock
             }

--- a/Pod/Classes/NSURLSession/MockRegister.swift
+++ b/Pod/Classes/NSURLSession/MockRegister.swift
@@ -18,12 +18,18 @@ class MockRegister {
         self.ephemeralMocks.removeAll()
     }
     
-    func addMock(mock: SessionMock) {
-        if mock.runsOnce {
-            self.ephemeralMocks.append(mock)
-        } else {
-            self.permanentMocks.append(mock)
-        }
+    /**
+     Adds a mock to the resgister that does not get removed after being returned
+    */
+    func addPermanentMock(mock: SessionMock) {
+        self.permanentMocks.append(mock)
+    }
+    
+    /**
+     Adds a mock to to the register that will be removed after being returned once
+    */
+    func addEphemeralMock(mock: SessionMock) {
+        self.ephemeralMocks.append(mock)
     }
     
     /**

--- a/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
+++ b/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
@@ -41,9 +41,9 @@ extension NSURLSession {
      - parameter statusCode: The status code (default=200) returned by the session data task
      - parameter delay: A artificial delay before the session data task starts to return response and data
      */
-    public class func mockSingle(request: NSURLRequest, body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) {
+    public class func mockNext(request: NSURLRequest, body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) {
         let matcher = SimpleRequestMatcher(url: request.URL!, method: request.HTTPMethod!)
-        self.mockSingle(matcher, response: { _ in MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
+        self.mockNext(matcher, response: { _ in MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
     }
     
     /**
@@ -70,9 +70,9 @@ extension NSURLSession {
      - parameter statusCode: The status code (default=200) returned by the session data task
      - parameter delay: A artificial delay before the session data task starts to return response and data
      */
-    public class func mockSingle(expression: String, HTTPMethod: String = "GET", body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) throws {
+    public class func mockNext(expression: String, HTTPMethod: String = "GET", body: NSData?, headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay) throws {
         let matcher = try SimpleRequestMatcher(expression: expression, method: HTTPMethod)
-        self.mockSingle(matcher, response: { _ in return MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
+        self.mockNext(matcher, response: { _ in return MockResponse(body: body, statusCode: statusCode, headers: headers) }, delay: delay)
     }
 
     /**
@@ -100,9 +100,9 @@ extension NSURLSession {
      - parameter delay: A artificial delay before the session data task starts to return response and data
      - parameter body: Returns data the data to be  returned by the session data task. If this returns `nil` then the didRecieveData callback won't be called.
      */
-    public class func mockSingle(expression: String, HTTPMethod: String = "GET", headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay, body: BodyFunction) throws {
+    public class func mockNext(expression: String, HTTPMethod: String = "GET", headers: [String: String] = [:], statusCode: Int = 200, delay: Double = DefaultDelay, body: BodyFunction) throws {
         let matcher = try SimpleRequestMatcher(expression: expression, method: HTTPMethod)
-        self.mockSingle(matcher, response: { (url: NSURL, extractions: [String]) in return MockResponse(body: body(extractions), statusCode: statusCode, headers: headers) }, delay: delay)
+        self.mockNext(matcher, response: { (url: NSURL, extractions: [String]) in return MockResponse(body: body(extractions), statusCode: statusCode, headers: headers) }, delay: delay)
     }
 
     /**
@@ -138,7 +138,7 @@ extension NSURLSession {
     //MARK: Private methods
     
     // Add a request matcher to the list of mocks
-    private class func mockSingle(matcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
+    private class func mockNext(matcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.register.addMock(SingleSuccessSessionMock(matching: matcher, response: response, delay: delay))
         swizzleIfNeeded()
     }

--- a/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
+++ b/Pod/Classes/NSURLSession/NSURLSession+Mock.swift
@@ -139,13 +139,15 @@ extension NSURLSession {
     
     // Add a request matcher to the list of mocks
     private class func mockNext(matcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
-        self.register.addMock(SingleSuccessSessionMock(matching: matcher, response: response, delay: delay))
+        let mock = SuccessSessionMock(matching: matcher, response: response, delay: delay)
+        self.register.addEphemeralMock(mock)
         swizzleIfNeeded()
     }
     
     // Add a request matcher to the list of mocks
     private class func mockEvery(matcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
-        self.register.addMock(SuccessSessionMock(matching: matcher, response: response, delay: delay))
+        let mock = SuccessSessionMock(matching: matcher, response: response, delay: delay)
+        self.register.addPermanentMock(mock)
         swizzleIfNeeded()
     }
 }

--- a/Pod/Classes/NSURLSession/NSURLSession+Swizzle.swift
+++ b/Pod/Classes/NSURLSession/NSURLSession+Swizzle.swift
@@ -111,7 +111,6 @@ extension NSURLSession {
     private func taskForRequest(request: NSURLRequest) -> NSURLSessionDataTask? {
         if let mock = NSURLSession.register.nextSessionMockForRequest(request) {
             return try! mock.consumeRequest(request, session: self)
-            
         }
         return nil
     }

--- a/Pod/Classes/NSURLSession/SessionMock.swift
+++ b/Pod/Classes/NSURLSession/SessionMock.swift
@@ -14,6 +14,11 @@ import Foundation
 protocol SessionMock {
     
     /**
+     Session mocks can either be run only once or forever until removed.
+    */
+    var runsOnce: Bool { get }
+    
+    /**
      For a given request, return `true` if this mock matches it (i.e. will return
      a data task from `consumeRequest(request:session:)`.
      */

--- a/Pod/Classes/NSURLSession/SessionMock.swift
+++ b/Pod/Classes/NSURLSession/SessionMock.swift
@@ -14,11 +14,6 @@ import Foundation
 protocol SessionMock {
     
     /**
-     Session mocks can either be run only once or forever until removed.
-    */
-    var runsOnce: Bool { get }
-    
-    /**
      For a given request, return `true` if this mock matches it (i.e. will return
      a data task from `consumeRequest(request:session:)`.
      */

--- a/Pod/Classes/NSURLSession/SuccessSessionMock.swift
+++ b/Pod/Classes/NSURLSession/SuccessSessionMock.swift
@@ -15,6 +15,8 @@ class SuccessSessionMock : SessionMock {
     private let requestMatcher: RequestMatcher
     private let response: MockResponseHandler
     private let delay: Double
+    
+    var runsOnce = false
 
     init(matching requestMatcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.requestMatcher = requestMatcher
@@ -84,23 +86,9 @@ class SuccessSessionMock : SessionMock {
 }
 
 class SingleSuccessSessionMock : SuccessSessionMock {
-
-    var canRun = true
-
-    override func matchesRequest(request: NSURLRequest) -> Bool {
-        return canRun && super.matchesRequest(request)
+    
+    override init(matching requestMatcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
+        super.init(matching: requestMatcher, response: response, delay: delay)
+        self.runsOnce = true
     }
-
-    override func consumeRequest(request: NSURLRequest, session: NSURLSession) throws -> NSURLSessionDataTask {
-        guard self.matchesRequest(request) else { throw SessionMockError.InvalidRequest(request: request) }
-
-        guard canRun else { throw SessionMockError.HasAlreadyRun }
-
-        let task = try super.consumeRequest(request, session: session)
-
-        canRun = false
-
-        return task
-    }
-
 }

--- a/Pod/Classes/NSURLSession/SuccessSessionMock.swift
+++ b/Pod/Classes/NSURLSession/SuccessSessionMock.swift
@@ -16,8 +16,6 @@ class SuccessSessionMock : SessionMock {
     private let response: MockResponseHandler
     private let delay: Double
     
-    var runsOnce = false
-
     init(matching requestMatcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
         self.requestMatcher = requestMatcher
         self.response = response
@@ -83,12 +81,4 @@ class SuccessSessionMock : SessionMock {
         }
     }
 
-}
-
-class SingleSuccessSessionMock : SuccessSessionMock {
-    
-    override init(matching requestMatcher: RequestMatcher, response: MockResponseHandler, delay: Double) {
-        super.init(matching: requestMatcher, response: response, delay: delay)
-        self.runsOnce = true
-    }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This pod is designed to help during functional testing by returning canned respo
 
 ### NSURLSession
 
-To mock a single request use `mockSingle` - this method can be called multiple times and the responses will be returned in the same order they were added in:
+To mock a single request use `mockNext` - this method can be called multiple times and the responses will be returned in the same order they were added in:
 
 ```objc
 let body1 = "Test response 1".dataUsingEncoding(NSUTF8StringEncoding)!
@@ -22,9 +22,10 @@ let URL = NSURL(string: "https://www.example.com/1")!
 let request = NSURLRequest.init(URL: URL)
 
 // Mock calls to that request returning both responses in turn
-NSURLSession.mockSingle(request, body: body1, delay: 1)
-NSURLSession.mockSingle(request, body: body2, delay: 1)
+NSURLSession.mockNext(request, body: body1, delay: 1)
+NSURLSession.mockNext(request, body: body2, delay: 1)
 ```
+
 
 To mock every call to a request, just use `mockEvery` instead:
 
@@ -37,6 +38,8 @@ The parameters `body` and `delay` are optional if you want you code to be a bit 
 ```objc
 NSURLSession.mockEvery(request)
 ```
+
+Ephemeral mocks have priority over permanent mocks. This is to say that, if you were to add permanent and ephemeral mocks for the same request, the ephemeral mocks would be returned and consumed first.
 
 If you want your response to depend on the URL called, you can pass in a function like this:
 


### PR DESCRIPTION
Fixes #22

Had a little time to think about this on the train yesterday and this seemed like the easiest way to do this. There's a slight change in functionality in the register in that it now removes single mocks from its datastore once they have been requested. I think this makes sense.

This change makes getting the next mock for a request O(n+m) instead of O(n). As a future improvement we could potentially look into having a more efficient data structure for the mocks. 
