### PR TITLE
Fix travis to actually run in all the destinations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ language: objective-c
 osx_image: xcode7.1
 
 env:
-  - DESTINATION="platform=iOS Simulator,name=iPhone 6,OS=9.1"
-  - DESTINATION="platform=iOS Simulator,name=iPhone 6,OS=8.4"
-  - DESTINATION="platform=iOS Simulator,name=iPad Air,OS=9.1"
-  - DESTINATION="platform=iOS Simulator,name=iPad Air,OS=8.4"
+  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.1'
+  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=8.4'
+  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=9.1'
+  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=8.4'
 
 #cache: cocoapods
 #podfile: Example/Podfile
@@ -18,5 +18,6 @@ env:
 #- pod install --project-directory=Example
 
 script:
-- set -o pipefail && xcodebuild test -destination=$DESTINATION -workspace Example/NSURLSession-Mock.xcworkspace -scheme NSURLSession-Mock-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty
+- set -o pipefail
+- xcodebuild test -destination "$DESTINATION" -workspace Example/NSURLSession-Mock.xcworkspace -scheme NSURLSession-Mock-Example -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO | xcpretty
 - pod lib lint


### PR DESCRIPTION
Sign, turns out that `-destination=xxx` doesn't actually set the destination on the xcodebuild command - you have to do `-destination xxx` instead.
