### PR TITLE
Swift23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # * https://github.com/supermarin/xcpretty#usage
 
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode8
 
 env:
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ osx_image: xcode8
 
 env:
   - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=9.1'
-  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=8.4'
+  - DESTINATION='platform=iOS Simulator,name=iPhone 6,OS=10.0'
   - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=9.1'
-  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=8.4'
+  - DESTINATION='platform=iOS Simulator,name=iPad Air,OS=10.0'
 
 #cache: cocoapods
 #podfile: Example/Podfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ env:
 
 #cache: cocoapods
 #podfile: Example/Podfile
-#before_install:
-#- gem install cocoapods # Since Travis is not always on latest version
+before_install:
+  - gem install cocoapods --pre # Since Travis is not always on latest version
 #- pod install --project-directory=Example
 
 script:

--- a/Example/NSURLSession-Mock.xcodeproj/project.pbxproj
+++ b/Example/NSURLSession-Mock.xcodeproj/project.pbxproj
@@ -238,9 +238,11 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -522,6 +524,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -535,6 +538,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -558,6 +562,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/NSURLSession-Mock_Tests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NSURLSession-Mock_Example.app/NSURLSession-Mock_Example";
 			};
 			name = Debug;
@@ -577,6 +582,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/NSURLSession-Mock_Tests-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/NSURLSession-Mock_Example.app/NSURLSession-Mock_Example";
 			};
 			name = Release;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -650,6 +650,14 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					71695CAA417731ECB86AD9465E5E7778 = {
+						LastSwiftMigration = 0800;
+					};
+					8D29C37474F8FC612E6578A8475A88ED = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -850,6 +858,7 @@
 				PRODUCT_NAME = Pods_NSURLSession_Mock_Example;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -880,6 +889,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1000,6 +1010,7 @@
 				PRODUCT_NAME = NSURLSession_Mock;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1076,6 +1087,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Tests/AFNetworkingTests.swift
+++ b/Example/Tests/AFNetworkingTests.swift
@@ -29,7 +29,7 @@ class AFNetworkingTests: XCTestCase {
 
         let manager = AFHTTPSessionManager()
         
-        manager.GET(URL.absoluteString, parameters: nil, success: { (task, response) -> Void in
+        manager.GET(URL.absoluteString!, parameters: nil, success: { (task, response) -> Void in
             
             XCTAssertEqual(response as? NSDictionary, [ "data": 1 ])
             
@@ -55,7 +55,7 @@ class AFNetworkingTests: XCTestCase {
         
         let manager = AFHTTPSessionManager()
         
-        manager.POST(URL.absoluteString, parameters: nil, success: { (task, response) -> Void in
+        manager.POST(URL.absoluteString!, parameters: nil, success: { (task, response) -> Void in
             
             XCTAssertEqual(response as? NSDictionary, [ "data": 2 ])
             

--- a/Example/Tests/MockRegisterTests.swift
+++ b/Example/Tests/MockRegisterTests.swift
@@ -20,7 +20,7 @@ class TestSessionMock : SessionMock, Equatable {
     }
     
     func matchesRequest(request: NSURLRequest) -> Bool {
-        return (request.URL?.absoluteString.containsString(requestString))!
+        return (request.URL?.absoluteString!.containsString(requestString))!
     }
     
     func consumeRequest(request: NSURLRequest, session: NSURLSession) throws -> NSURLSessionDataTask {
@@ -137,7 +137,7 @@ class MockRegisterTests: XCTestCase {
             }
             
             func matchesRequest(request: NSURLRequest) -> Bool {
-                return (request.URL?.absoluteString.containsString(requestString))!
+                return (request.URL?.absoluteString!.containsString(requestString))!
             }
             
             func consumeRequest(request: NSURLRequest, session: NSURLSession) throws -> NSURLSessionDataTask {

--- a/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
+++ b/Pod/Classes/NSURLSession/Matchers/SimpleRequestMatcher.swift
@@ -19,7 +19,7 @@ struct SimpleRequestMatcher : RequestMatcher {
     let method: String
 
     init(url: NSURL, method: String) {
-        let path = NSRegularExpression.escapedPatternForString(url.absoluteString)
+        let path = NSRegularExpression.escapedPatternForString(url.absoluteString!)
         try! self.init(expression: "^\(path)$", method: method)
     }
 


### PR DESCRIPTION
Move to swift 2.3 so we are compatible with Xcode 8. There are no plans to be backwards compatible with Xcode 7.

Swift 3 coming soon(ish) - depending on that's complexity I'll decide whether to keep backwards compatibility between 2.3 and 3 - but net-a-porter itself is moving to swift 3 so we might just tag a release as the last 2.3 compatible one and move on. Not sure yet.
